### PR TITLE
Added publiccode.yaml

### DIFF
--- a/publiccode.yaml
+++ b/publiccode.yaml
@@ -1,0 +1,40 @@
+publiccodeYmlVersion: "0.2"
+name: Signalen classification
+url: "https://github.com/Signalen/classification"
+softwareVersion: "1"
+releaseDate: "2021-05-06"
+platforms:
+  - web
+categories:
+  - it-development
+usedBy:
+  - Gemeente Amsterdam
+developmentStatus: development
+softwareType: standalone/Api
+description:
+  nl:
+    localisedName: Signalen backend
+    genericName: Signalen backend
+    shortDescription: >-
+      Flask api and the code to retrain the model, which requires data, both extracted out of SIA and some dumps out of old systems.
+    longDescription: >-
+      Flask api and the code to retrain the model, which requires data, both extracted out of SIA and some dumps out of old systems.
+    documentation: "https://github.com/Signalen/classification/blob/master/README.md"
+    features:
+legal:
+  license: EUPL-1.2
+  mainCopyrightOwner: Signalen
+  repoOwner: Signalen
+maintenance:
+  type: external
+  contacts:
+    - name: Jacco Brouwer
+      email: jacco.brouwer@vng.nl
+localisation:
+  localisationReady: true
+  availableLanguages:
+    - nl
+    - en
+dependsOn:
+  open:
+    - name: signalen/classification


### PR DESCRIPTION
Added publiccode.yaml following the standard of:
https://docs.italia.it/italia/developers-italia/publiccodeyml-en/en/master/index.html

We have filled in as much information as we could.
But we suggest to check if they are correct.

Adding the publiccode.yaml file allows Dash Kube to correctly index this component at the commonground page found at:
https://dashkube.com/commonground

It also allows for one button installation of the signalen application via Dash Kube.